### PR TITLE
fix: removed san-serif of font family 🐛

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,8 +76,8 @@ module.exports = {
         700: "700",
       },
       fontFamily: {
-        lexend: ["Lexend", "sans-serif"],
-        inter: ["Inter", "sans-serif"],
+        lexend: ["Lexend", ""],
+        inter: ["Inter", ""],
       },
     },
   },


### PR DESCRIPTION
Now fonts families can be directly accessed by classname like: `font-inter`.